### PR TITLE
Fixed Bug: Removed excessive 'and'

### DIFF
--- a/TextNumber.js
+++ b/TextNumber.js
@@ -69,8 +69,20 @@ class TextNumber {
 				i++;
 			} while (i * 3 < str.length)
 		}
-	
-		return result.trim().replace(/\s+/g, ' ');
+		
+		result = result.trim().replace(/\s+/g, ' ');
+		
+		if (result.endsWith(this.and.trim())) {
+		    result = result.substr(0, result.length - this.and.trim().length);
+	    	}
+		if (result.endsWith(this.and2.trim())) {
+		    result = result.substr(0, result.length - this.and2.trim().length);
+	    	}
+		if (result.endsWith(this.and3.trim())) {
+		    result = result.substr(0, result.length - this.and3.trim().length);
+	    	}
+
+		return result;
 	}
 }
 

--- a/index.cjs.js
+++ b/index.cjs.js
@@ -99,7 +99,21 @@ var TextNumber = /*#__PURE__*/function () {
         } while (i * 3 < str.length);
       }
 
-      return result.trim().replace(/\s+/g, ' ');
+      result = result.trim().replace(/\s+/g, ' ');
+
+      if (result.endsWith(this.and.trim())) {
+        result = result.substr(0, result.length - this.and.trim().length);
+      }
+
+      if (result.endsWith(this.and2.trim())) {
+        result = result.substr(0, result.length - this.and2.trim().length);
+      }
+
+      if (result.endsWith(this.and3.trim())) {
+        result = result.substr(0, result.length - this.and3.trim().length);
+      }
+
+      return result;
     }
   }]);
 

--- a/index.esm.js
+++ b/index.esm.js
@@ -70,7 +70,19 @@ class TextNumber {
 			} while (i * 3 < str.length)
 		}
 	
-		return result.trim().replace(/\s+/g, ' ');
+		result = result.trim().replace(/\s+/g, ' ');
+		
+		if (result.endsWith(this.and.trim())) {
+		    result = result.substr(0, result.length - this.and.trim().length);
+	    	}
+		if (result.endsWith(this.and2.trim())) {
+		    result = result.substr(0, result.length - this.and2.trim().length);
+	    	}
+		if (result.endsWith(this.and3.trim())) {
+		    result = result.substr(0, result.length - this.and3.trim().length);
+	    	}
+			
+		return result;
 	}
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-number",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "This tiny library contains classes which can be used to convert numbers into English/Farsi/Persian and Arabic languages. Other languages can be added easily by sub-classing TextNumber class.",
   "main": "index.cjs.js",
   "module": "index.esm.js",


### PR DESCRIPTION
Hi

There is a bug in TextNumber class that results in an excessive 'and' being added at the end of numbers passed to text() method. I noticed the bug in TextNumberFa(). I didn't check other languages, but I think they too have this bug.

The workaround I used is checking the generated result whether it ends with an 'and' (and, and2, and3, any of them). If the result ends with them, remove the extra 'and' from the end of the resulting string.

I also increased package version number in package.json.

I appreciate it if you publish the package in npm, so that we can update text-number in our projects.

Bests,
MO