### PR TITLE
Fixed bug: undefined does not have a toString() method'; 

### DIFF
--- a/index.cjs.js
+++ b/index.cjs.js
@@ -50,7 +50,7 @@ var TextNumber = /*#__PURE__*/function () {
     key: "_text2",
     value: function _text2(n) {
       var result = "";
-      n = n || this.value;
+      n = n || this.value || '0';
 
       if (n < 10) {
         result = this.ones[n];
@@ -68,7 +68,7 @@ var TextNumber = /*#__PURE__*/function () {
   }, {
     key: "_text3",
     value: function _text3(n) {
-      n = n || this.value;
+      n = n || this.value || '0';
       var one = Math.floor(n / 100);
       var rest = n - one * 100;
       return (one > 0 ? this.hundreds[one - 1] : "") + (rest > 0 ? (one > 0 ? this.and3 : "") + this._text2(rest) : "");
@@ -76,13 +76,13 @@ var TextNumber = /*#__PURE__*/function () {
   }, {
     key: "text",
     value: function text(n) {
-      n = n || this.value;
+      n = n || this.value || '0';
       var result = [];
       var i = 0;
       var str = n.toString();
 
       if (n == 0) {
-        result = this.zero;
+        result = [this.zero];
       } else {
         do {
           var from = str.length - (i + 1) * 3;

--- a/index.esm.js
+++ b/index.esm.js
@@ -17,7 +17,7 @@ class TextNumber {
 	_text2(n) {
 		let result = "";
 
-		n = n || this.value;
+		n = n || this.value || '0';
 
 		if (n < 10) {
 			result = this.ones[n];
@@ -36,7 +36,7 @@ class TextNumber {
 		return result;
 	}
 	_text3(n) {
-		n = n || this.value;
+		n = n || this.value || '0';
 
 		const one = Math.floor(n / 100);
 		const rest = n - one * 100;
@@ -44,14 +44,14 @@ class TextNumber {
 		return (one > 0 ? this.hundreds[one - 1] : "") + (rest > 0 ? (one > 0 ? this.and3 : "") + this._text2(rest) : "");
 	}
 	text(n) {
-		n = n || this.value;
+		n = n || this.value || '0';
 
 		let result = [];
 		let i = 0;
 		const str = n.toString();
 
 		if (n == 0) {
-			result = this.zero;
+			result = [this.zero];
 		} else {
 			do {
 				let from = str.length - (i + 1) * 3;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-number",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "This tiny library contains classes which can be used to convert numbers into English/Farsi/Persian and Arabic languages. Other languages can be added easily by sub-classing TextNumber class.",
   "main": "index.cjs.js",
   "module": "index.esm.js",


### PR DESCRIPTION
I found another bug in the library.

When you pass 0 number to text() method, the method generates a "TypeError: Cannot read property 'toString' of undefined".

The root cause of the problem was that the result 0 || undefined is undefined. When n is 0 and this.value is undefined (which most of time is), the n parameter will be overwritten by undefined, hence n.toString() generates and error.

Moreover, there was another error for 0 inputs: result.reverse is not a function.

The error was due to forgetting setting an array value to result variable when n is zero. (result = this.zero).

In this pull-request both bugs are resolved and fixed.

Thank you again.
MO